### PR TITLE
Adding support for pausing on non-acceptance tests

### DIFF
--- a/src/Codeception/Extension/PauseOnFail.php
+++ b/src/Codeception/Extension/PauseOnFail.php
@@ -14,8 +14,11 @@ class PauseOnFail extends Extension {
 
     public function pause(TestEvent $event)
     {
-        $I = new \AcceptanceTester($event->getTest()->getScenario());
-        $I->pause();
+	    $metaData = $event->getTest()->getMetadata()->getCurrent();
+
+	    $actor = $metaData['actor'];
+	    $I = new $actor($event->getTest()->getScenario());
+	    $I->pause();
     }
 }
 


### PR DESCRIPTION
Instead of hard-coding the Acceptance tester, this change will use metadata to find the current actor's class name instead, so that the extension will work non Acceptance Tests also.